### PR TITLE
feat: fix router and add error boundary

### DIFF
--- a/src/ErrorBoundary.jsx
+++ b/src/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error(
+      error,
+      info.componentStack,
+      React.captureOwnerStack(),
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from "react-router";
-import { ThemeProvider } from 'styled-components';
-import theme from './styles/theme';
 import Home from './components/Home';
 import Login from './components/LoginRegistration/Login';
 import Registration from './components/LoginRegistration/Registration';
@@ -13,7 +11,6 @@ import NotFound from './components/NotFound';
 import ThankYou from './components/ThankYou';
 
 const Router = () => (
-  <ThemeProvider theme={theme}>
     <BrowserRouter>
       <Routes>
         <Route index element={<Home/>}/>
@@ -30,7 +27,6 @@ const Router = () => (
         <Route path='404' element={<NotFound/>}/>
       </Routes>
     </BrowserRouter>
-  </ThemeProvider>
 );
 
 

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { createBrowserRouter } from 'react-router';
-import { RouterProvider } from 'react-router/dom';
+import { BrowserRouter, Routes, Route } from "react-router";
 import { ThemeProvider } from 'styled-components';
 import theme from './styles/theme';
 import Home from './components/Home';
@@ -12,49 +11,27 @@ import Cart from './components/CartCheckout/Cart';
 import Checkout from './components/CartCheckout/Checkout';
 import NotFound from './components/NotFound';
 import ThankYou from './components/ThankYou';
-import PrivateRoute from './components/PrivateRoute';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    children: [
-      { index: true, Component: Home },
-      { path: 'login', Component: Login },
-      { path: 'register', Component: Registration },
-      {
-        path: 'products',
-        children: [
-          { index: true, Component: Products },
-          { path: ':product', Component: ProductDetails },
-        ],
-      },
-      {
-        path: 'cart',
-        Component: Cart,
-      },
-      {
-        path: 'checkout',
-        Component: Checkout,
-      },
-      {
-        path: 'thankyou',
-        Component: ThankYou,
-      },
-      {
-        path: '404',
-        Component: NotFound,
-      },
-      {
-        path: '*',
-        Component: NotFound,
-      },
-    ],
-  },
-]);
-const Routes = () => (
+const Router = () => (
   <ThemeProvider theme={theme}>
-    <RouterProvider router={router} />
+    <BrowserRouter>
+      <Routes>
+        <Route index element={<Home/>}/>
+        <Route path='login' element={<Login/>}/>
+        <Route path='register' element={<Registration/>}/>
+        <Route path='cart' element={<Cart/>}/>
+        <Route path='checkout' element={<Checkout/>}/>
+        <Route path='thankyou' element={<ThankYou/>}/>
+        <Route path='products'>
+          <Route index element={<Products/>}/>
+          <Route path=':product' element={<ProductDetails/>}/>
+        </Route>
+        <Route path='*' element={<NotFound/>}/>
+        <Route path='404' element={<NotFound/>}/>
+      </Routes>
+    </BrowserRouter>
   </ThemeProvider>
 );
 
-export default Routes;
+
+export default Router;

--- a/src/components/BuyByeBuy.jsx
+++ b/src/components/BuyByeBuy.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import theme from '../styles/theme';
 import MyProvider from '../context/MyProvider';
-import FetchData from '../FetchData';
 import Router from '../Routes';
 
 const BuyByeBuy = () => {
-	return (
-		<MyProvider>
-			<FetchData />
-			<Router />
-		</MyProvider>
-	)
-}
+  return (
+    <MyProvider>
+      <ThemeProvider theme={theme}>
+        <Router />
+      </ThemeProvider>
+    </MyProvider>
+  );
+};
 
 export default BuyByeBuy;

--- a/src/components/BuyByeBuy.jsx
+++ b/src/components/BuyByeBuy.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import MyProvider from '../context/MyProvider';
 import FetchData from '../FetchData';
-import Routes from '../Routes';
+import Router from '../Routes';
 
 const BuyByeBuy = () => {
 	return (
 		<MyProvider>
 			<FetchData />
-			<Routes />
+			<Router />
 		</MyProvider>
 	)
 }

--- a/src/components/BuyByeBuy.jsx
+++ b/src/components/BuyByeBuy.jsx
@@ -3,14 +3,17 @@ import { ThemeProvider } from 'styled-components';
 import theme from '../styles/theme';
 import MyProvider from '../context/MyProvider';
 import Router from '../Routes';
+import ErrorBoundary from '../ErrorBoundary';
 
 const BuyByeBuy = () => {
   return (
+    <ErrorBoundary>
     <MyProvider>
       <ThemeProvider theme={theme}>
         <Router />
       </ThemeProvider>
     </MyProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/components/LoginRegistration/Registration.jsx
+++ b/src/components/LoginRegistration/Registration.jsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useReducer,
 } from 'react';
-import { redirect } from 'react-router';
+import { useNavigate } from 'react-router';
 import Header from '../Header';
 import MyContext from '../../context/MyContext';
 import { signupErrorReducer } from '../../reducers/signupErrorReducer';
@@ -17,6 +17,7 @@ const Registration = () => {
   const [error, dispatchError] = useReducer(signupErrorReducer, '');
   const [confirmPW, setConfirmPW] = useState('');
   const focusField = useRef();
+  const navigate = useNavigate();
 
   useEffect(() => {
     focusField.current.focus();
@@ -38,11 +39,8 @@ const Registration = () => {
     if (userData.password !== confirmPW)
       return handleInputError('DISPLAY_MISMATCH');
     dispatchError('DISPLAY_NULL');
+    navigate('/products');
   };
-
-  if (!error && error !== '') {
-    throw redirect('/products');
-  }
 
   return (
     <StyledRegistrationPage>

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -10,7 +10,6 @@ const PrivateRoute = ({ component: Component, redirectTo }) => {
     navigate(redirectTo)
   } else {
     return <Component/>
-
   }
   
 ;

--- a/src/components/ProductsPage/ProductCard.jsx
+++ b/src/components/ProductsPage/ProductCard.jsx
@@ -5,7 +5,7 @@ import { StyledProductCard } from './styles';
 import { displayPrice } from '../../helpers/sanitizeData';
 import { addNewItem, removeItem } from '../../helpers/cartHelpers';
 
-const ProductCard = ({ idx, title, info, price, image, description }) => {
+const ProductCard = ({ idx, title, info, price, image }) => {
   const { cart, setCart, userData } = useContext(MyContext);
 
   return (
@@ -15,13 +15,6 @@ const ProductCard = ({ idx, title, info, price, image, description }) => {
       <NavLink
         className='product-card-clickable'
         to={`${title}`}
-        state={{
-          title,
-          price,
-          image,
-          description,
-          idx,
-        }}
       >
         {info} &amp; more...
       </NavLink>

--- a/src/components/SingleProduct/index.jsx
+++ b/src/components/SingleProduct/index.jsx
@@ -51,7 +51,7 @@ const ProductDetails = () => {
         <h2 className='product-title'>{title}</h2>
         <p className='product-description'>{description}</p>
         <div className='product-btns'>
-          <Button className='back' onClick={() => navigate(-1)}>
+          <Button className='back' onClick={() => navigate('/products')}>
             Back
           </Button>
           <Button

--- a/src/components/SingleProduct/index.jsx
+++ b/src/components/SingleProduct/index.jsx
@@ -1,49 +1,36 @@
 import React, { useContext } from 'react';
+import { useParams } from 'react-router';
 import Header from '../Header';
 import Footer from '../Footer';
-import { Link, useNavigate, useLocation, redirect } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import MyContext from '../../context/MyContext';
 import StyledProductPage from './styles';
 import { Button } from '../../styles/globalStyles';
 import { displayPrice } from '../../helpers/sanitizeData';
 import { addNewItem } from '../../helpers/cartHelpers';
+import NotFound from '../NotFound';
 
 const ProductDetails = () => {
-  const { products, qty, cart, setCart, userData } = useContext(MyContext);
-  console.log({ products, qty, cart, setCart, userData });
-
+  const params = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
 
-  console.log({ location });
+  const { products, qty, cart, setCart, userData } = useContext(MyContext);
 
   if (products.length === 0) return null;
 
   const displayedProduct = products.find((product) => {
-    return product.title === location.state.title;
+    return product.title === params.product;
   });
-  console.log({ displayedProduct });
+
+  // handle redirect if the product is not found
+
   if (!displayedProduct) {
-    redirect('/404');
+    return <NotFound />;
   }
 
   // The product is defined either by URL params or by the item clicked on the Products page:
 
-  let title, description, image, price, idx;
-
-  if (location.state) {
-    title = location.state.title;
-    description = location.state.description;
-    image = location.state.image;
-    price = location.state.price;
-    idx = location.state.idx;
-  } else {
-    title = displayedProduct.title[0];
-    description = displayedProduct.description[0];
-    image = displayedProduct.image[0];
-    price = displayedProduct.price[0];
-    idx = displayedProduct.id;
-  }
+  const { title, description, image, price, id } = displayedProduct;
 
   return (
     <StyledProductPage>
@@ -70,7 +57,7 @@ const ProductDetails = () => {
           <Button
             className='buy'
             onClick={() =>
-              addNewItem(userData, cart, setCart, idx, title, price)
+              addNewItem(userData, cart, setCart, id, title, price)
             }
           >
             <span>Buy</span>

--- a/src/context/MyProvider.jsx
+++ b/src/context/MyProvider.jsx
@@ -1,58 +1,64 @@
 import React, { useState } from 'react';
 import MyContext from './MyContext';
+import data from '../data/products.json';
 
 const MyProvider = (props) => {
-	// products-related data
-	
-	const [products, setProducts] = useState([]);
+  // products-related data
 
-	
-	// user-related data
-	
-	const users = {
-		'admin': 'iamtheboss',
-		'olhanotolga': 'bestpassword'
-	}
-	
-	const [userData, setUserData] = useState({username: '', password: ''});
+  const [products, setProducts] = useState(data.products);
 
+  // user-related data
 
-	// shopping cart
-	
-	const [cart, setCart] = useState({});
-	const [qty, setQty] = useState(0);
-	const [subtotal, setSubtotal] = useState(0);
-	const [shipping, setShipping] = useState(0);
-	const [total, setTotal] = useState(0);
+  const users = {
+    admin: 'iamtheboss',
+    olhanotolga: 'bestpassword',
+  };
 
-	
-	// FUNCTIONS
+  const [userData, setUserData] = useState({ username: '', password: '' });
 
-	const reset = () => {
-		setCart({});
-		setQty(0);
-		setSubtotal(0);
-		setShipping(0);
-		setTotal(0);
-		setUserData({username: '', password: ''});
-	}
+  // shopping cart
 
+  const [cart, setCart] = useState({});
+  const [qty, setQty] = useState(0);
+  const [subtotal, setSubtotal] = useState(0);
+  const [shipping, setShipping] = useState(0);
+  const [total, setTotal] = useState(0);
 
-	return (
-		<MyContext.Provider value={{
-			products, setProducts,
-			users,
-			userData, setUserData,
-			cart, setCart,
-			qty, setQty,
-			subtotal, setSubtotal,
-			shipping, setShipping,
-			total, setTotal,
-			reset
-		}}>
-			{props.children}
-		</MyContext.Provider>
-	)
-}
+  // FUNCTIONS
+
+  const reset = () => {
+    setCart({});
+    setQty(0);
+    setSubtotal(0);
+    setShipping(0);
+    setTotal(0);
+    setUserData({ username: '', password: '' });
+  };
+
+  return (
+    <MyContext.Provider
+      value={{
+        products,
+        setProducts,
+        users,
+        userData,
+        setUserData,
+        cart,
+        setCart,
+        qty,
+        setQty,
+        subtotal,
+        setSubtotal,
+        shipping,
+        setShipping,
+        total,
+        setTotal,
+        reset,
+      }}
+    >
+      {props.children}
+    </MyContext.Provider>
+  );
+};
 
 export default MyProvider;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'build'),
     filename: 'bundle.js',
     clean: true,
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
This PR:
- fixes routing to a product page by setting `publicPath` in the Webpack config file;
- decides upon using Declarative mode of React Router (this is a simple application, after all);
- adds React error boundary to log errors in a potentially more meaningful way;
- fixes navigation from Registration page;
- amends navigation back from the single product view: now it always leads to Products and not one page back.